### PR TITLE
Always activate periodic tick command on workqueue

### DIFF
--- a/pkg/controllermanager/controller/pool.go
+++ b/pkg/controllermanager/controller/pool.go
@@ -154,10 +154,7 @@ func (p *pool) Period() time.Duration {
 }
 
 func (p *pool) StartTicker() {
-	if p.period != 0 {
-		p.Infof("start ticker")
-		p.workqueue.AddAfter(tickCmd, p.period)
-	}
+	// noop as periodic tick is always activated
 }
 
 func (p *pool) Run() {
@@ -166,8 +163,10 @@ func (p *pool) Run() {
 	if period == 0 {
 		p.Infof("no reconcile period active -> start ticker")
 		period = tick
-		p.workqueue.AddAfter(tickCmd, tick)
 	}
+	// always run periodic tickCmd to deal with empty workqueue
+	p.workqueue.AddAfter(tickCmd, period)
+
 	healthz.Start(p.Key(), period)
 	for i := 0; i < p.size; i++ {
 		p.startWorker(i, p.ctx.Done())

--- a/pkg/controllermanager/controller/worker.go
+++ b/pkg/controllermanager/controller/worker.go
@@ -160,7 +160,7 @@ func (w *worker) processNextWorkItem() bool {
 				}
 			}
 			if status.Interval >= 0 {
-				w.Infof("requested reschedule %d seconds", status.Interval/time.Second)
+				w.Debugf("requested reschedule %d seconds", status.Interval/time.Second)
 			}
 			updateSchedule(&reschedule, status.Interval)
 		}

--- a/pkg/resources/keys.go
+++ b/pkg/resources/keys.go
@@ -84,7 +84,11 @@ func NewClusterKey(cluster string, groupKind schema.GroupKind, namespace, name s
 }
 
 func (this ClusterObjectKey) String() string {
-	return fmt.Sprintf("%s/%s", this.cluster, this.objectKey.ObjectKey)
+	return this.asString()
+}
+
+func (this ClusterObjectKey) asString() string {
+	return fmt.Sprintf("%s:%s", this.cluster, this.objectKey.ObjectKey)
 }
 
 func (this ClusterObjectKey) Cluster() string {
@@ -98,9 +102,8 @@ func (this ClusterObjectKey) ObjectKey() ObjectKey {
 func (this ClusterObjectKey) AsRefFor(clusterid string) string {
 	if this.cluster == clusterid {
 		return this.objectKey.String()
-	} else {
-		return fmt.Sprintf("%s:%s", this.cluster, this.objectKey.ObjectKey.String())
 	}
+	return this.asString()
 }
 
 func ParseClusterObjectKey(clusterid string, key string) (ClusterObjectKey, error) {

--- a/pkg/resources/obj_lifecycle.go
+++ b/pkg/resources/obj_lifecycle.go
@@ -44,7 +44,7 @@ func (this *_object) IsDeleting() bool {
 
 func (this *_object) Update() error {
 	result, err := this.resource._update(this.ObjectData)
-	if err != nil {
+	if err == nil {
 		this.ObjectData = result
 	}
 	return err
@@ -55,7 +55,7 @@ func (this *_object) UpdateStatus() error {
 		return fmt.Errorf("resource %q has no status sub resource", this.resource.GroupVersionKind())
 	}
 	result, err := this.resource._updateStatus(this.ObjectData)
-	if err != nil {
+	if err == nil {
 		this.ObjectData = result
 	}
 	return err

--- a/pkg/resources/subcache.go
+++ b/pkg/resources/subcache.go
@@ -141,6 +141,7 @@ func (this *SubObjectCache) DeleteOwner(key ClusterObjectKey) {
 		for s := range slaves {
 			this.removeByKey(key, s)
 		}
+		delete(this.byOwner, key)
 	}
 }
 


### PR DESCRIPTION
If there are no source resources defined, the workqueue stays empty, no tick calls are performed and the liveness check fails after some time. Therefore the periodic tick command is now activated always.
