### PR TITLE
specify lease cluster optionally

### DIFF
--- a/pkg/controllermanager/controller/extension.go
+++ b/pkg/controllermanager/controller/extension.go
@@ -249,7 +249,8 @@ func (this *Extension) Start(ctx context.Context) error {
 	for _, cntr := range this.controllers {
 		def := this.registrations[cntr.GetName()]
 		if def.RequireLease() {
-			this.getLeaseStartupGroup(cntr.GetMainCluster()).Add(cntr)
+			cluster := cntr.GetCluster(def.LeaseClusterName())
+			this.getLeaseStartupGroup(cluster).Add(cntr)
 		} else {
 			this.getPlainStartupGroup(cntr.GetMainCluster()).Add(cntr)
 		}

--- a/pkg/controllermanager/controller/interface.go
+++ b/pkg/controllermanager/controller/interface.go
@@ -166,6 +166,7 @@ type Definition interface {
 	RequiredControllers() []string
 	CustomResourceDefinitions() map[string][]*apiextensions.CustomResourceDefinitionVersions
 	RequireLease() bool
+	LeaseClusterName() string
 	FinalizerName() string
 	ActivateExplicitly() bool
 	ConfigOptions() map[string]OptionDefinition


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently every controller performs leader election in its "MAIN" cluster.
A component with multiple controllers in multiple clusters can therefore have leader elections in multiple clusters.
This may or may not be the wished behaviour.
With this PR the `RequireLease` controller definition option can take an optional cluster name argument to explicitly speficy the cluster for its leader election.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
