### PR TITLE
foreign owner groupkind migration

### DIFF
--- a/pkg/controllermanager/configure.go
+++ b/pkg/controllermanager/configure.go
@@ -26,6 +26,7 @@ type Configuration struct {
 
 	globalMinimalWatch  resources.GroupKindSet
 	clusterMinimalWatch map[string]resources.GroupKindSet
+	groupKindMigrations []schema.GroupKind
 }
 
 type configState struct {
@@ -80,6 +81,11 @@ func (this Configuration) GlobalMinimalWatch(groupKinds ...schema.GroupKind) Con
 	return this
 }
 
+func (this Configuration) GlobalGroupKindMigrations(groupKinds ...schema.GroupKind) Configuration {
+	this.groupKindMigrations = append(this.groupKindMigrations, groupKinds...)
+	return this
+}
+
 func (this Configuration) MinimalWatch(clusterName string, groupKinds ...schema.GroupKind) Configuration {
 	m, ok := this.clusterMinimalWatch[clusterName]
 	if !ok {
@@ -124,5 +130,6 @@ func (this Configuration) Definition() Definition {
 		description:  this.description,
 		extensions:   this.extension_reg.GetDefinitions(),
 		cluster_defs: cluster_defs,
+		gkMigrations: this.groupKindMigrations,
 	}
 }

--- a/pkg/controllermanager/controller/reconcile/reconcilers/simpleslavecache.go
+++ b/pkg/controllermanager/controller/reconcile/reconcilers/simpleslavecache.go
@@ -25,25 +25,24 @@ var slavesKey = ctxutil.SimpleKey("slaves")
 // GetSharedSimpleSlaveCache returns an instance of a usage cache unique for
 // the complete controller manager
 func GetSharedSimpleSlaveCache(controller controller.Interface) *SimpleSlaveCache {
-	mig := controller.GetEnvironment().ControllerManager().GetClusterIdMigration()
+	var clustermig = controller.GetEnvironment().ControllerManager().GetClusterIdMigration()
+	var gkmig = controller.GetEnvironment().ControllerManager().GetGroupKindMigration()
 	return controller.GetEnvironment().GetOrCreateSharedValue(slavesKey, func() interface{} {
-		return NewSimpleSlaveCache(mig)
+		return NewSimpleSlaveCache(clustermig, gkmig)
 	}).(*SimpleSlaveCache)
 }
 
 type SimpleSlaveCache struct {
-	migration resources.ClusterIdMigration
-	usages    *SimpleUsageCache
+	migration   resources.ClusterIdMigration
+	gkMigration resources.GroupKindMigration
+	usages      *SimpleUsageCache
 }
 
-func NewSimpleSlaveCache(migration ...resources.ClusterIdMigration) *SimpleSlaveCache {
-	var mig resources.ClusterIdMigration
-	if len(migration) > 0 {
-		mig = migration[0]
-	}
+func NewSimpleSlaveCache(clustermig resources.ClusterIdMigration, gkmig resources.GroupKindMigration) *SimpleSlaveCache {
 	return &SimpleSlaveCache{
-		migration: mig,
-		usages:    NewSimpleUsageCache(),
+		migration:   clustermig,
+		gkMigration: gkmig,
+		usages:      NewSimpleUsageCache(),
 	}
 }
 
@@ -76,6 +75,12 @@ func (this *SimpleSlaveCache) SetupFor(log logger.LogContext, resc resources.Int
 	return ProcessResource(log, "setup owners for", resc, func(log logger.LogContext, obj resources.Object) (bool, error) {
 		if this.migration != nil {
 			err := resources.MigrateOwnerClusterIds(obj, this.migration)
+			if err != nil {
+				return false, err
+			}
+		}
+		if this.gkMigration != nil {
+			err := resources.MigrateGroupKinds(obj, this.gkMigration)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -42,7 +42,8 @@ type ControllerManager struct {
 	config   *areacfg.Config
 	clusters cluster.Clusters
 
-	migrations resources.ClusterIdMigration
+	migrations   resources.ClusterIdMigration
+	gkMigrations resources.GroupKindMigration
 }
 
 var _ extension.ControllerManager = &ControllerManager{}
@@ -174,6 +175,7 @@ func NewControllerManager(ctx context.Context, def Definition) (*ControllerManag
 		list = append(list, clusters.GetCluster(c))
 	}
 	cm.migrations = resources.ClusterIdMigrationFor(list...)
+	cm.gkMigrations = resources.GroupKindMigrationFor(def.GroupKindMigrations()...)
 
 	for _, n := range cm.order {
 		e := cm.extensions[n]
@@ -226,6 +228,10 @@ func (this *ControllerManager) GetClusters() cluster.Clusters {
 
 func (this *ControllerManager) GetClusterIdMigration() resources.ClusterIdMigration {
 	return this.migrations
+}
+
+func (this *ControllerManager) GetGroupKindMigration() resources.GroupKindMigration {
+	return this.gkMigrations
 }
 
 func (this *ControllerManager) GetDefaultScheme() *runtime.Scheme {

--- a/pkg/controllermanager/definition.go
+++ b/pkg/controllermanager/definition.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	areacfg "github.com/gardener/controller-manager-library/pkg/controllermanager/config"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/extension"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Definition interface {
@@ -20,6 +22,7 @@ type Definition interface {
 	ExtensionDefinition(name string) extension.Definition
 	ClusterDefinitions() cluster.Definitions
 	ExtendConfig(cfg *configmain.Config)
+	GroupKindMigrations() []schema.GroupKind
 }
 
 type _Definition struct {
@@ -27,6 +30,7 @@ type _Definition struct {
 	description  string
 	extensions   extension.ExtensionDefinitions
 	cluster_defs cluster.Definitions
+	gkMigrations []schema.GroupKind
 }
 
 func (this *_Definition) GetName() string {
@@ -66,6 +70,10 @@ func (this *_Definition) ExtendConfig(cfg *configmain.Config) {
 		e.ExtendConfig(ccfg)
 	}
 	this.cluster_defs.ExtendConfig(ccfg)
+}
+
+func (this *_Definition) GroupKindMigrations() []schema.GroupKind {
+	return this.gkMigrations
 }
 
 func DefaultDefinition(name, desc string) Definition {

--- a/pkg/controllermanager/extension/extension.go
+++ b/pkg/controllermanager/extension/extension.go
@@ -180,6 +180,7 @@ type ControllerManager interface {
 	GetExtension(name string) Extension
 
 	GetClusterIdMigration() resources.ClusterIdMigration
+	GetGroupKindMigration() resources.GroupKindMigration
 }
 
 type Environment interface {

--- a/pkg/controllermanager/main.go
+++ b/pkg/controllermanager/main.go
@@ -30,8 +30,12 @@ const DeletionActivity = "DeletionActivity"
 
 var Version = "dev-version"
 
-func Start(use, short, long string) {
-	PrepareStart(use, long).Start(use, short)
+func Start(use, short, long string, modifiers ...ConfigurationModifier) {
+	c := PrepareStart(use, long)
+	for _, m := range modifiers {
+		c = m(c)
+	}
+	c.Start(use, short)
 }
 
 func PrepareStart(use, long string) Configuration {

--- a/pkg/resources/abstract/keys.go
+++ b/pkg/resources/abstract/keys.go
@@ -98,6 +98,11 @@ func (this ClusterObjectKey) ChangeCluster(id string) ClusterObjectKey {
 	return this
 }
 
+func (this ClusterObjectKey) ChangeGroupKind(gk schema.GroupKind) ClusterObjectKey {
+	this.groupKind = gk
+	return this
+}
+
 func (this ClusterObjectKey) String() string {
 	return this.asString()
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -63,9 +63,17 @@ type ClusterIdMigrationProvider interface {
 	GetClusterIdMigration() ClusterIdMigration
 }
 
+type GroupKindMigrationProvider interface {
+	GetGroupKindMigration() GroupKindMigration
+}
+
 type ClusterIdMigration interface {
 	RequireMigration(id string) string
 	String() string
+}
+
+type GroupKindMigration interface {
+	RequireMigration(gk schema.GroupKind) *schema.GroupKind
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -188,6 +188,26 @@ func RemoveOwnerReference(o ObjectData, ref *metav1.OwnerReference) bool {
 	return false
 }
 
+func RemoveOwnerReferenceByKey(o ObjectData, key ObjectKey) bool {
+	refs := o.GetOwnerReferences()
+	for i, r := range refs {
+		if r.Kind == key.Kind() && r.Name == key.Name() && matchGroup(r.APIVersion, key.Group()) {
+			refs = append(refs[:i], refs[i+1:]...)
+			o.SetOwnerReferences(refs)
+			return true
+		}
+	}
+	return false
+}
+
+func matchGroup(apiVersion, group string) bool {
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return false
+	}
+	return gv.Group == group
+}
+
 func FilterKeysByGroupKinds(keys ClusterObjectKeySet, kinds ...schema.GroupKind) ClusterObjectKeySet {
 
 	if len(kinds) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds optional migration of the GroupKind part of owner annotations (`resources.gardener.cloud/owners`).
This is needed e.g. to update the owner annotation of `extensions/Ingress` to `networking.k8s.io/Ingress` for `Ingress` source objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
support for foreign owner groupkind migration
```
