### PR TITLE
Fix creating namespaced informers

### DIFF
--- a/pkg/resources/informers.go
+++ b/pkg/resources/informers.go
@@ -260,7 +260,7 @@ func (f *sharedFilteredInformerFactory) lookupInformerFor(gvk schema.GroupVersio
 	if err != nil {
 		return nil, err
 	}
-	return f.getFactory("", nil).informerFor(lwFactory)
+	return f.getFactory(namespace, nil).informerFor(lwFactory)
 }
 
 func (f *sharedFilteredInformerFactory) InformerFor(gvk schema.GroupVersionKind) (GenericInformer, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to ensure that only namespaced informer is created if requested.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Fix creating namespaced informers
```
