### PR TITLE
Change default lease leader election resource lock to 'configmapsleases'

### DIFF
--- a/pkg/controllermanager/controller/lease/config.go
+++ b/pkg/controllermanager/controller/lease/config.go
@@ -11,18 +11,21 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 type Config struct {
-	OmitLease          bool
-	LeaseName          string
-	LeaseDuration      time.Duration
-	LeaseRenewDeadline time.Duration
-	LeaseRetryPeriod   time.Duration
+	OmitLease                       bool
+	LeaseName                       string
+	LeaseLeaderElectionResourceLock string
+	LeaseDuration                   time.Duration
+	LeaseRenewDeadline              time.Duration
+	LeaseRetryPeriod                time.Duration
 }
 
 func (this *Config) AddOptionsToSet(set config.OptionSet) {
 	set.AddStringOption(&this.LeaseName, "lease-name", "", "", "name for lease object")
+	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'configmapsleases'")
 	set.AddBoolOption(&this.OmitLease, "omit-lease", "", false, "omit lease for development")
 	set.AddDurationOption(&this.LeaseDuration, "lease-duration", "", 15*time.Second, "lease duration")
 	set.AddDurationOption(&this.LeaseRenewDeadline, "lease-renew-deadline", "", 10*time.Second, "lease renew deadline")

--- a/pkg/controllermanager/controller/lease/lease.go
+++ b/pkg/controllermanager/controller/lease/lease.go
@@ -31,7 +31,7 @@ func MakeLeaderElectionConfig(cluster cluster.Interface, namespace string, confi
 		return nil, err
 	}
 	lock, err := resourcelock.New(
-		"configmaps",
+		config.LeaseLeaderElectionResourceLock,
 		namespace,
 		config.LeaseName,
 		client.CoreV1(),


### PR DESCRIPTION
**What this PR does / why we need it**:
The default of the leader election resource lock is changed from `configmaps` to `configmapsleases` to prepare migration to leader election with lease objects.
Additionally there is a new command line option `--lease-resource-lock` to specify the resource lock type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Change default lease leader election resource lock from 'configmaps' to 'configmapsleases'
```
