### PR TITLE
Fix CustomResourceDefinition for Kubernetes v1.22

### DIFF
--- a/pkg/resources/apiextensions/versions.go
+++ b/pkg/resources/apiextensions/versions.go
@@ -32,6 +32,7 @@ type CustomResourceDefinitionVersions struct {
 	versioned *utils.Versioned
 }
 
+var v122 = semver.MustParse("1.22.0")
 var v116 = semver.MustParse("1.16.0")
 var v112 = semver.MustParse("1.12.0")
 var otype runtime.Object


### PR DESCRIPTION
**What this PR does / why we need it**:
Deployment of `CustomResourceDefinition` is fixed for Kubernetes v1.22 which needs apiVersion `apiextensions.k8s.io/v1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix CustomResourceDefinition for Kubernetes v1.22
```
