### PR TITLE
fix crd generation if value contains backticks

### DIFF
--- a/hack/generate-crds
+++ b/hack/generate-crds
@@ -11,7 +11,7 @@ loop()
     if [ -f "$f" ]; then
       cat <<EOF
 ${TAB}data = \`
-$(cat "$f")
+$(sed -E 's/`/`+"`"+`/g' $f)
   \`
 ${TAB}utils.Must(registry.RegisterCRD(data))
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes syntax errors in the generated go file if a string value (e.g. description) contains backticks.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fix crd generation if a string value contains backticks
```
