### PR TITLE
Fix data race in slave cache

### DIFF
--- a/pkg/resources/subcache.go
+++ b/pkg/resources/subcache.go
@@ -98,7 +98,7 @@ func (this *SubObjectCache) GetSubObject(key ClusterObjectKey) Object {
 	if o == nil {
 		return nil
 	}
-	return o.object
+	return o.object.DeepCopy()
 }
 
 func (this *SubObjectCache) GetOwners(key ClusterObjectKey, kinds ...schema.GroupKind) ClusterObjectKeySet {
@@ -215,7 +215,7 @@ func (this *SubObjectCache) GetByOwnerKey(key ClusterObjectKey) []Object {
 	keys := this.byOwner[key]
 	result := []Object{}
 	for k := range keys {
-		result = append(result, this.subObjects[k].object)
+		result = append(result, this.subObjects[k].object.DeepCopy())
 	}
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Subobjects from the slave cache can be used for updates which can lead to data races. Therefore it must only work with copies.

