### PR TITLE
Add resources handlers to handlersByObjType map for reuse

### DIFF
--- a/pkg/resources/abstract/resources.go
+++ b/pkg/resources/abstract/resources.go
@@ -191,7 +191,12 @@ func (this *AbstractResources) _newResource(gvk schema.GroupVersionKind, otype r
 		return nil, errors.New(errors.ERR_NO_LIST_TYPE, "cannot determine list type for %s", otype)
 	}
 
-	return this.newResource(this.self, gvk, otype, ltype)
+	resource, err := this.newResource(this.self, gvk, otype, ltype)
+	if err != nil {
+		return nil, err
+	}
+	this.handlersByObjType[otype] = resource
+	return resource, nil
 }
 
 type getResource func(gvk schema.GroupVersionKind) (Resource, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
The resource handlers should be stored for later reuse as otherwise the caching of informers may not work correctly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix developer
Add resources handlers to handlersByObjType map for reuse
```
