### PR TITLE
Switch default leader election resource lock to leases

### DIFF
--- a/pkg/controllermanager/controller/lease/config.go
+++ b/pkg/controllermanager/controller/lease/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func (this *Config) AddOptionsToSet(set config.OptionSet) {
 	set.AddStringOption(&this.LeaseName, "lease-name", "", "", "name for lease object")
-	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'configmapsleases'")
+	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.LeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'leases'")
 	set.AddBoolOption(&this.OmitLease, "omit-lease", "", false, "omit lease for development")
 	set.AddDurationOption(&this.LeaseDuration, "lease-duration", "", 15*time.Second, "lease duration")
 	set.AddDurationOption(&this.LeaseRenewDeadline, "lease-renew-deadline", "", 10*time.Second, "lease renew deadline")


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch default leader election resource lock from `configmapsleases` to `leases`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Switch default leader election resource lock from `configmapsleases` to `leases`
```
