### PR TITLE
Fix panic if ServerResourcesForGroupVersion fails

### DIFF
--- a/pkg/resources/info.go
+++ b/pkg/resources/info.go
@@ -185,9 +185,10 @@ func (this *ResourceInfos) doUpdateGroup(dc *discovery.DiscoveryClient, group v1
 		if err != nil {
 			lastErr = err
 		}
-		if list != nil {
-			count += len(list.APIResources)
+		if list == nil {
+			continue
 		}
+		count += len(list.APIResources)
 
 		func() {
 			this.lock.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix panic if ServerResourcesForGroupVersion fails.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1418679]

goroutine 1 [running]:
github.com/gardener/controller-manager-library/pkg/resources.(*ResourceInfos).doUpdateGroup.func1(0xc0008775c0, {{{0x0, 0x0}, {0x0, 0x0}}, {0xc000c067c0, 0x10}, {0xc0001ca980, 0x2, 0x4}, ...}, ...)
	/build/vendor/github.com/gardener/controller-manager-library/pkg/resources/info.go:201 +0x179
github.com/gardener/controller-manager-library/pkg/resources.(*ResourceInfos).doUpdateGroup(0x5cf?, 0x2361b81?, {{{0x0, 0x0}, {0x0, 0x0}}, {0xc000c067c0, 0x10}, {0xc0001ca980, 0x2, ...}, ...})
	/build/vendor/github.com/gardener/controller-manager-library/pkg/resources/info.go:221 +0xae
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bug developer
Fix panic if ServerResourcesForGroupVersion fails
```
