### PR TITLE
Increase RSA key size to 3072 bits

### DIFF
--- a/pkg/utils/pkiutil/pki_helpers.go
+++ b/pkg/utils/pkiutil/pki_helpers.go
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// made changes:
+// rsaKeySize was changed from 2048 to 3072
+
 package pkiutil
 
 import (
@@ -21,7 +24,7 @@ const (
 	CertificateBlockType = "CERTIFICATE"
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
-	rsaKeySize             = 2048
+	rsaKeySize             = 3072
 )
 
 // NewPrivateKey creates an RSA private key


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/8635

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The library now uses 3072 bit RSA keys.
```
