### PR TITLE
Allow to deactivate controller on specific creation errors

### DIFF
--- a/pkg/controllermanager/controller/configure.go
+++ b/pkg/controllermanager/controller/configure.go
@@ -254,6 +254,8 @@ type _Definition struct {
 	activateExplicitly   bool
 	scheme               *runtime.Scheme
 	extensions           map[ExtensionKey]interface{}
+
+	deactivateOnCreationErrorCheck func(err error) bool
 }
 
 var _ Definition = &_Definition{}
@@ -423,6 +425,10 @@ func (this *_Definition) ConfigOptionSources() extension.OptionSourceDefinitions
 
 func (this *_Definition) ActivateExplicitly() bool {
 	return this.activateExplicitly
+}
+
+func (this *_Definition) DeactivateOnCreationErrorCheck() func(err error) bool {
+	return this.deactivateOnCreationErrorCheck
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1011,6 +1017,11 @@ func (this Configuration) Register(group ...string) error {
 
 func (this Configuration) MustRegister(group ...string) Configuration {
 	registry.MustRegisterController(this, group...)
+	return this
+}
+
+func (this Configuration) DeactivateOnCreationErrorCheck(check func(err error) bool) Configuration {
+	this.settings.deactivateOnCreationErrorCheck = check
 	return this
 }
 

--- a/pkg/controllermanager/controller/extension.go
+++ b/pkg/controllermanager/controller/extension.go
@@ -236,6 +236,12 @@ func (this *Extension) Start(ctx context.Context) error {
 		}
 		cntr, err := NewController(this, def, cmp)
 		if err != nil {
+			if f := def.DeactivateOnCreationErrorCheck(); f != nil {
+				if f(err) {
+					this.Infof("deactivating controller %s because of: %s", def.Name(), err)
+					continue
+				}
+			}
 			return err
 		}
 

--- a/pkg/controllermanager/controller/interface.go
+++ b/pkg/controllermanager/controller/interface.go
@@ -240,6 +240,7 @@ type Definition interface {
 	LeaseClusterName() string
 	FinalizerName() string
 	ActivateExplicitly() bool
+	DeactivateOnCreationErrorCheck() func(err error) bool
 
 	GetDefinitionExtension(ExtensionKey) interface{}
 

--- a/pkg/controllermanager/controller/reconcile/reconcilers/utils.go
+++ b/pkg/controllermanager/controller/reconcile/reconcilers/utils.go
@@ -17,17 +17,17 @@ import (
 )
 
 func ClusterResources(cluster string, gks ...schema.GroupKind) Resources {
-	return func(c controller.Interface) []resources.Interface {
+	return func(c controller.Interface) ([]resources.Interface, error) {
 		result := []resources.Interface{}
 		resources := c.GetCluster(cluster).Resources()
 		for _, gk := range gks {
 			res, err := resources.Get(gk)
 			if err != nil {
-				panic(fmt.Errorf("resources type %s not found: %s", gk, err))
+				return nil, fmt.Errorf("resources type %s not found: %s", gk, err)
 			}
 			result = append(result, res)
 		}
-		return result
+		return result, nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It is now possible to deactivate a controller, if it creation fails with specific errors.
For this purpose a controller definition method `DeactivateOnCreationErrorCheck` was added to set a function which checks if an error during controller creation should be ignored and the controller just left deactivated.

Additionally the error handling for UsageAccess and SlaveAccess have been improved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added controller definition method `DeactivateOnCreationErrorCheck` to support dynamic deactivation of a controller during its creation.
```
