### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /test-webhook
 /example
 
-/hack/tools
+/hack/tools/bin
 /args
 /bin
 /.kube-secrets
@@ -24,3 +24,6 @@
 # Virtual go & fuse
 .virtualgo
 .fuse_hidden*
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ tidy:
 	go mod tidy
 
 .PHONY: check
-check: format $(GOIMPORTS) $(GOLANGCI_LINT)
+check: sast-report fastcheck
+
+.PHONY: fastcheck
+fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)
 	@TOOLS_BIN_DIR="$(TOOLS_DIR)/bin" ./hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/...
 	@echo "Running go vet..."
 	@go vet ./cmd/... ./pkg/...
-
 
 .PHONY: build
 build:
@@ -39,3 +41,11 @@ generate: $(VGOPATH)
 .PHONY: format
 format:
 	@go fmt ./cmd/... ./pkg/...
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true

--- a/cmd/test/certs/certs.go
+++ b/cmd/test/certs/certs.go
@@ -97,15 +97,17 @@ func CertsMain() {
 	}
 
 	tlscfg := &tls.Config{
+		MinVersion:     tls.VersionTLS12,
 		GetCertificate: cert.GetCertificate,
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", HelloServer)
 	server := http.Server{
-		Addr:      ":8443",
-		TLSConfig: tlscfg,
-		Handler:   mux,
+		Addr:              ":8443",
+		TLSConfig:         tlscfg,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
 	}
 
 	fmt.Printf("Starting server\n")

--- a/cmd/test/field/field.go
+++ b/cmd/test/field/field.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -248,7 +247,7 @@ func FieldMain() {
 	tArray1()
 	t0()
 	t1()
-	data, err := ioutil.ReadFile("local/test.yaml")
+	data, err := os.ReadFile("local/test.yaml")
 	if err == nil {
 		d := yaml.NewDecoder(bytes.NewBuffer(data))
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack -exclude-dir=local -exclude=G115 $gosec_report_parse_flags ./...

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -9,6 +9,7 @@ KUBEBUILDER_DIR          := "$(shell realpath $(TOOLS_DIR))/bin/kube_builder_$(K
 KUBEBUILDER_ASSETS       := $(KUBEBUILDER_DIR)/bin
 CONTROLLER_GEN           := $(TOOLS_BIN_DIR)/controller-gen
 GOLANGCI_LINT            := $(TOOLS_BIN_DIR)/golangci-lint
+GOSEC                    := $(TOOLS_BIN_DIR)/gosec
 GOIMPORTS                := $(TOOLS_BIN_DIR)/goimports
 GINKGO                   := $(TOOLS_BIN_DIR)/ginkgo
 VGOPATH                  := $(TOOLS_BIN_DIR)/vgopath
@@ -18,6 +19,7 @@ export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
 GOLANGCI_LINT_VERSION ?= v1.61.0
 VGOPATH_VERSION ?= v0.1.5
+GOSEC_VERSION ?= v2.21.4
 
 # Use this function to get the version of a go module from go.mod
 version_gomod = $(shell go list -mod=mod -f '{{ .Version }}' -m $(1))
@@ -60,3 +62,6 @@ $(KUBEBUILDER_TAG): $(call tool_version_file,$(KUBEBUILDER_TAG),$(KUBEBUILDER_K8
 
 $(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))
 	go build -o $(VGOPATH) github.com/ironcore-dev/vgopath
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) bash $(TOOLS_DIR)/install-gosec.sh

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/pkg/certmgmt/load.go
+++ b/pkg/certmgmt/load.go
@@ -7,29 +7,30 @@
 package certmgmt
 
 import (
-	"io/ioutil"
+	"os"
+	"path/filepath"
 )
 
 func LoadCertInfo(certFile, keyFile, caFile, cakeyFile string) (CertificateInfo, error) {
-	certPEMBlock, err := ioutil.ReadFile(certFile)
+	certPEMBlock, err := os.ReadFile(filepath.Clean(certFile))
 	if err != nil {
 		return NewCertInfo(nil, nil, nil, nil), err
 	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	keyPEMBlock, err := os.ReadFile(filepath.Clean(keyFile))
 	if err != nil {
 		return NewCertInfo(certPEMBlock, nil, nil, nil), err
 	}
 
 	var caPEMBlock []byte
 	if caFile != "" {
-		caPEMBlock, err = ioutil.ReadFile(caFile)
+		caPEMBlock, err = os.ReadFile(filepath.Clean(caFile))
 		if err != nil {
 			return NewCertInfo(certPEMBlock, keyPEMBlock, nil, nil), err
 		}
 	}
 	var cakeyPEMBlock []byte
 	if cakeyFile != "" {
-		cakeyPEMBlock, err = ioutil.ReadFile(cakeyFile)
+		cakeyPEMBlock, err = os.ReadFile(filepath.Clean(cakeyFile))
 		if err != nil {
 			return NewCertInfo(certPEMBlock, keyPEMBlock, caPEMBlock, nil), err
 		}

--- a/pkg/config/configfile.go
+++ b/pkg/config/configfile.go
@@ -9,7 +9,8 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
@@ -63,7 +64,7 @@ func MergeFlags(flags *pflag.FlagSet, args []string, override bool) error {
 // ReadConfigFile reads a yaml or json file are parses its content to
 // a list of equivalent command line arguments
 func ReadConfigFile(name string, flags *pflag.FlagSet) ([]string, error) {
-	bytes, err := ioutil.ReadFile(name)
+	bytes, err := os.ReadFile(filepath.Clean(name))
 
 	if err != nil {
 		return nil, err

--- a/pkg/controllermanager/examples/apis/example/v1alpha1/register.go
+++ b/pkg/controllermanager/examples/apis/example/v1alpha1/register.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,7 +38,7 @@ func init() {
 	// makes the code compile even when the generated files are missing.
 	localSchemeBuilder.Register(addDefaultingFuncs, addKnownTypes)
 
-	resources.Register(SchemeBuilder)
+	utils.Must(resources.Register(SchemeBuilder))
 }
 
 // Adds the list of known types to api.Scheme.

--- a/pkg/controllermanager/examples/controller/test/controller.go
+++ b/pkg/controllermanager/examples/controller/test/controller.go
@@ -100,10 +100,17 @@ func (h *reconciler) Setup() error {
 	return nil
 }
 
-func (h *reconciler) Start() {
-	h.controller.EnqueueCommand("poll")
-	h.controller.WithLease("temporary", false, h.temporary)
-	h.controller.WithLease("ongoing", true, h.exclusive)
+func (h *reconciler) Start() error {
+	if err := h.controller.EnqueueCommand("poll"); err != nil {
+		return err
+	}
+	if err := h.controller.WithLease("temporary", false, h.temporary); err != nil {
+		return err
+	}
+	if err := h.controller.WithLease("ongoing", true, h.exclusive); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (h *reconciler) Command(logger logger.LogContext, cmd string) reconcile.Status {

--- a/pkg/controllermanager/examples/server/test/server.go
+++ b/pkg/controllermanager/examples/server/test/server.go
@@ -20,12 +20,12 @@ func init() {
 	server.Configure("test").AllowSecretMaintenance(true).
 		RegisterHandler("demo", server.HandlerFunc("demo", http.HandlerFunc(demo))).
 		RegisterHandler("message", Create).
-		Register()
+		MustRegister()
 }
 
 func demo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("this is a test"))
+	_, _ = w.Write([]byte("this is a test"))
 }
 
 type Handler struct {
@@ -55,7 +55,7 @@ func (this *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	m := this.shared.Values["message"]
 	if m == nil {
-		w.Write([]byte("no message configured\n"))
+		_, _ = w.Write([]byte("no message configured\n"))
 	}
-	w.Write([]byte(fmt.Sprintf("%s\n", m)))
+	_, _ = w.Write([]byte(fmt.Sprintf("%s\n", m)))
 }

--- a/pkg/resources/conditions/conditions.go
+++ b/pkg/resources/conditions/conditions.go
@@ -173,14 +173,14 @@ func (this *Condition) set(name string, value interface{}) (bool, error) {
 			tmp := reflect.New(f.Type()).Elem()
 			f := tmp.Field(0)
 			if !f.CanSet() {
-				f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // yepp, access unexported fields
+				f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // #nosec G103 -- needed to access unexported fields
 			}
 			f.Set(vv)
 			vv = tmp
 		}
 	}
 	if !f.CanSet() {
-		f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // yepp, access unexported fields
+		f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // #nosec G103 -- needed to access unexported fields
 	}
 	old := f.Interface()
 	if !reflect.DeepEqual(old, value) {

--- a/pkg/resources/informerfactories.go
+++ b/pkg/resources/informerfactories.go
@@ -149,7 +149,7 @@ func panicWatchErrorHandler(r *cache.Reflector, err error) {
 func resyncPeriod(resync time.Duration) func() time.Duration {
 	return func() time.Duration {
 		// the factor will fall into [0.9, 1.1)
-		factor := rand.Float64()/5.0 + 0.9
+		factor := rand.Float64()/5.0 + 0.9 // #nosec G404 -- no cryptographic us
 		return time.Duration(float64(resync.Nanoseconds()) * factor)
 	}
 }

--- a/pkg/run/config.go
+++ b/pkg/run/config.go
@@ -7,8 +7,8 @@
 package run
 
 import (
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
@@ -39,7 +39,7 @@ func (this *Config) AddOptionsToSet(set config.OptionSet) {
 		namespace = n
 	} else {
 		f := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-		bytes, err := ioutil.ReadFile(f)
+		bytes, err := os.ReadFile(filepath.Clean(f))
 		if err == nil {
 			n = string(bytes)
 			n = strings.TrimSpace(n)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -61,6 +61,7 @@ func (this *HTTPServer) Start(source certs.CertificateSource, bindAddress string
 		this.Infof("starting %s as https server (serving on %s)", this.name, listenAddress)
 		tlscfg = &tls.Config{
 			NextProtos:     []string{"h2"},
+			MinVersion:     tls.VersionTLS12,
 			GetCertificate: source.GetCertificate,
 		}
 		for _, f := range tweak {
@@ -70,9 +71,10 @@ func (this *HTTPServer) Start(source certs.CertificateSource, bindAddress string
 		this.Infof("starting %s as http server (serving on %s)", this.name, listenAddress)
 	}
 	this.server = &http.Server{
-		Addr:      listenAddress,
-		Handler:   this.servMux,
-		TLSConfig: tlscfg,
+		Addr:              listenAddress,
+		Handler:           this.servMux,
+		TLSConfig:         tlscfg,
+		ReadHeaderTimeout: 3 * time.Second,
 	}
 
 	ctxutil.WaitGroupAdd(this.ctx)

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -35,7 +35,7 @@ func SetValue(f reflect.Value, v interface{}) error {
 	}
 	if !f.CanSet() {
 		if !f.CanInterface() && f.CanAddr() {
-			f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // yepp, access unexported fields
+			f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // #nosec G103 -- needed to access unexported fields
 		}
 	}
 	f.Set(vv)
@@ -44,7 +44,7 @@ func SetValue(f reflect.Value, v interface{}) error {
 
 func GetValue(f reflect.Value) interface{} {
 	if !f.CanInterface() && f.CanAddr() {
-		f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // yepp, access unexported fields
+		f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem() // #nosec G103 -- needed to access unexported fields
 	}
 	return f.Interface()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` from gardener/gardener as introduced in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gosec` was introduced for Static Application Security Testing (SAST).
```
