### PR TITLE
Optionally redirect logging and disable option logging

### DIFF
--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -46,13 +46,20 @@ type ControllerManager struct {
 
 var _ extension.ControllerManager = &ControllerManager{}
 
+// DisableOptionSettingsLogging disables the logging of option settings on calling NewControllerManager.
+var DisableOptionSettingsLogging bool
+
 func NewControllerManager(ctx context.Context, def Definition) (*ControllerManager, error) {
 	maincfg := configmain.Get(ctx)
 	cfg := areacfg.GetConfig(maincfg)
 	lgr := logger.New()
-	logger.Info("using option settings:")
-	config.Print(logger.Infof, "", cfg.OptionSet)
-	logger.Info("-----------------------")
+	if DisableOptionSettingsLogging {
+		logger.Info("option settings logging is disabled")
+	} else {
+		logger.Info("using option settings:")
+		config.Print(logger.Infof, "", cfg.OptionSet)
+		logger.Info("-----------------------")
+	}
 	ctx = logger.Set(ctxutil.WaitGroupContext(ctx, "controllermanager"), lgr)
 	ctx = context.WithValue(ctx, resources.ATTR_EVENTSOURCE, def.GetName()) // //nolint:staticcheck
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -8,6 +8,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -30,6 +31,7 @@ type LogContext interface {
 	Errorf(msgfmt string, args ...interface{})
 }
 
+// SetLevel sets the log level for the default logger.
 func SetLevel(name string) error {
 	lvl, err := logrus.ParseLevel(name)
 	if err != nil {
@@ -39,6 +41,11 @@ func SetLevel(name string) error {
 	logrus.SetLevel(lvl)
 	defaultLogger.SetLevel(lvl)
 	return nil
+}
+
+// SetOutput sets the logger output for the default logger.
+func SetOutput(output io.Writer) {
+	defaultLogger.SetOutput(output)
 }
 
 type _context struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
The method `logger.SetOutput` allows to redirect the logging output.
The flag `controllermanager. DisableOptionSettingsLogging = true` disables the lengthy logging of all options.
Both methods are useful for integration tests starting the controller manager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Optionally redirect logging and disable option logging
```
