### PR TITLE
Delay logging from init methods

### DIFF
--- a/pkg/controllermanager/controller/registry.go
+++ b/pkg/controllermanager/controller/registry.go
@@ -108,7 +108,7 @@ func (this *_Registry) RegisterController(reg Registerable, group ...string) err
 	if d, ok := this.definitions[def.Name()]; ok && d != def {
 		return fmt.Errorf("multiple registration of controller %q", def.Name())
 	}
-	logger.Infof("Registering controller %s", def.Name())
+	logger.InitInfof("Registering controller %s", def.Name())
 
 	if len(group) == 0 {
 		err := this.addToGroup(def, groups.DEFAULT)

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -50,6 +50,7 @@ var _ extension.ControllerManager = &ControllerManager{}
 var DisableOptionSettingsLogging bool
 
 func NewControllerManager(ctx context.Context, def Definition) (*ControllerManager, error) {
+	logger.OutputInitLogging()
 	maincfg := configmain.Get(ctx)
 	cfg := areacfg.GetConfig(maincfg)
 	lgr := logger.New()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -98,7 +98,7 @@ func OutputInitLogging() {
 	if out == nil || !initOut.CompareAndSwap(out, nil) {
 		return
 	}
-	fmt.Fprintln(defaultLogger.Out, out.String())
+	_, _ = fmt.Fprintln(defaultLogger.Out, out.String())
 }
 
 func NewContext(key, value string) LogContext {

--- a/pkg/resources/apiextensions/registry.go
+++ b/pkg/resources/apiextensions/registry.go
@@ -52,7 +52,7 @@ func (this *_registry) RegisterCRD(spec CRDSpecification) error {
 	}
 	this.lock.Lock()
 	defer this.lock.Unlock()
-	logger.Infof("found crd specification %s: %s", crds.GroupKind(), crds.GetDefault().CRDVersions())
+	logger.InitInfof("found crd specification %s: %s", crds.GroupKind(), crds.GetDefault().CRDVersions())
 	this.registry[crds.GroupKind()] = crds
 	return nil
 }

--- a/pkg/server/static.go
+++ b/pkg/server/static.go
@@ -15,11 +15,11 @@ import (
 var servMux = http.NewServeMux()
 
 func Register(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	logger.Infof("adding %s endpoint", pattern)
+	logger.InitInfof("adding %s endpoint", pattern)
 	servMux.HandleFunc(pattern, handler)
 }
 
 func RegisterHandler(pattern string, handler http.Handler) {
-	logger.Infof("adding %s endpoint", pattern)
+	logger.InitInfof("adding %s endpoint", pattern)
 	servMux.Handle(pattern, handler)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Delay logging from init methods to call of `controllermanager.NewControllerManager` to avoid nasty logging in unit tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Delay logging from init methods to call of `controllermanager.NewControllerManager`
```
