### PR TITLE
Make QPS and burst to apiserver configurable

### DIFF
--- a/pkg/controllermanager/cluster/cluster.go
+++ b/pkg/controllermanager/cluster/cluster.go
@@ -245,6 +245,13 @@ func CreateCluster(ctx context.Context, logger logger.LogContext, def Definition
 		return nil, err
 	}
 
+	if cfg.QPS > 0 {
+		kubeConfig.QPS = float32(cfg.QPS)
+	}
+	if cfg.Burst > 0 {
+		kubeConfig.Burst = cfg.Burst
+	}
+
 	return CreateClusterForScheme(ctx, logger, def, id, kubeConfig, nil)
 }
 

--- a/pkg/controllermanager/cluster/config.go
+++ b/pkg/controllermanager/cluster/config.go
@@ -23,6 +23,12 @@ const SUBOPTION_DISABLE_DEPLOY_CRDS = "disable-deploy-crds"
 // garden namespace deploying it.
 const SUBOPTION_CONDITIONAL_DEPLOY_CRDS = "conditional-deploy-crds"
 
+// SUBOPTION_QPS is an option to set the maximum QPS to the apiserver of the cluster.
+const SUBOPTION_QPS = "qps"
+
+// SUBOPTION_BURST is an option to set the maximum burst to the apiserver of the cluster.
+const SUBOPTION_BURST = "burst"
+
 const ConditionalDeployCRDIgnoreSetAttrKey = "conditional_deploy_ignore_set"
 
 type Config struct {
@@ -32,6 +38,8 @@ type Config struct {
 	MigrationIds    utils.StringSet
 	OmitCRDs        bool
 	ConditionalCRDs bool
+	QPS             int
+	Burst           int
 
 	migrationIds string
 
@@ -55,6 +63,8 @@ func NewConfig(def Definition) *Config {
 	cfg.AddStringOption(&cfg.migrationIds, SUBOPTION_MIGIDS, "", "", fmt.Sprintf("migration id for cluster %s", def.Name()))
 	cfg.AddBoolOption(&cfg.OmitCRDs, SUBOPTION_DISABLE_DEPLOY_CRDS, "", false, fmt.Sprintf("disable deployment of required crds for cluster %s", def.Name()))
 	cfg.AddBoolOption(&cfg.ConditionalCRDs, SUBOPTION_CONDITIONAL_DEPLOY_CRDS, "", false, fmt.Sprintf("deployment of required crds for cluster %s only if there is no managed resource in garden namespace deploying it", def.Name()))
+	cfg.AddIntOption(&cfg.QPS, SUBOPTION_QPS, "", 0, fmt.Sprintf("option to set the maximum QPS to the apiserver of the cluster %s", def.Name()))
+	cfg.AddIntOption(&cfg.Burst, SUBOPTION_BURST, "", 0, fmt.Sprintf("option to set the maximum burst to the apiserver of the cluster %s", def.Name()))
 	_ = callExtensions(func(e Extension) error { e.ExtendConfig(def, cfg); return nil })
 	return cfg
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The client to the kube-apiserver has a default rate limiting of QPS = 5. New command line options are introduced to make it configurable per cluster, e.g. `--kubeconfig.qps` and `--kubeconfig.burst`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Make QPS and burst to apiserver configurable.
```
