### PR TITLE
Provide higher default values for QPS and burst

### DIFF
--- a/pkg/controllermanager/cluster/config.go
+++ b/pkg/controllermanager/cluster/config.go
@@ -68,8 +68,8 @@ func NewConfig(def Definition) *Config {
 	cfg.AddBoolOption(&cfg.OmitCRDs, SUBOPTION_DISABLE_DEPLOY_CRDS, "", false, fmt.Sprintf("disable deployment of required crds for cluster %s", def.Name()))
 	cfg.AddBoolOption(&cfg.ConditionalCRDs, SUBOPTION_CONDITIONAL_DEPLOY_CRDS, "", false, fmt.Sprintf("deployment of required crds for cluster %s only if there is no managed resource in garden namespace deploying it", def.Name()))
 	cfg.AddBoolOption(&cfg.CRDsShootNoCleanupLabel, SUBOPTION_CRDS_SHOOT_NO_CLEANUP_LABEL, "", false, fmt.Sprintf("add the label 'shoot.gardener.cloud/no-cleanup=true' for CRDS deployed on cluster %s", def.Name()))
-	cfg.AddIntOption(&cfg.QPS, SUBOPTION_QPS, "", 0, fmt.Sprintf("option to set the maximum QPS to the apiserver of the cluster %s", def.Name()))
-	cfg.AddIntOption(&cfg.Burst, SUBOPTION_BURST, "", 0, fmt.Sprintf("option to set the maximum burst to the apiserver of the cluster %s", def.Name()))
+	cfg.AddIntOption(&cfg.QPS, SUBOPTION_QPS, "", 50, fmt.Sprintf("option to set the maximum QPS to the apiserver of the cluster %s", def.Name()))
+	cfg.AddIntOption(&cfg.Burst, SUBOPTION_BURST, "", 100, fmt.Sprintf("option to set the maximum burst to the apiserver of the cluster %s", def.Name()))
 	_ = callExtensions(func(e Extension) error { e.ExtendConfig(def, cfg); return nil })
 	return cfg
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
The standard default values for the QPS and burst for request to the kube-apiserver provided by k8s.io/client-go package are very low: `QPS=5` and `burst=10`.
With this PR the new default values are `QPS=50` and `burst=100`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Provide higher default values for `QPS=50` and `burst=100`
```
